### PR TITLE
fix: allow large WASM bytecode in CREATE opcode, instead of RWASM

### DIFF
--- a/crates/interpreter/src/instructions/contract.rs
+++ b/crates/interpreter/src/instructions/contract.rs
@@ -8,7 +8,7 @@ use crate::{
     primitives::{
         eof::EofHeader, keccak256, Address, BerlinSpec, Bytes, Eof, Spec, SpecId::*, B256, U256,
     },
-    primitives::rwasm::RWASM_MAGIC_BYTES,
+    primitives::rwasm::WASM_MAGIC_BYTES,
     CallInputs, CallScheme, CallValue, CreateInputs, CreateScheme, EOFCreateInputs, Host,
     InstructionResult, InterpreterAction, InterpreterResult, MAX_INITCODE_SIZE, WASM_MAX_CODE_SIZE,
 };
@@ -352,10 +352,10 @@ pub fn create<const IS_CREATE2: bool, H: Host + ?Sized, SPEC: Spec>(
                 .limit_contract_code_size
                 .map(|limit| limit.saturating_mul(2))
                 .unwrap_or_else(|| {
-                    if len >= RWASM_MAGIC_BYTES.len()
+                    if len >= WASM_MAGIC_BYTES.len()
                         && interpreter
                         .shared_memory
-                        .slice(code_offset, RWASM_MAGIC_BYTES.len()) == RWASM_MAGIC_BYTES.as_ref()
+                        .slice(code_offset, WASM_MAGIC_BYTES.len()) == WASM_MAGIC_BYTES.as_ref()
                     {
                         WASM_MAX_CODE_SIZE
                     } else {

--- a/crates/primitives/src/bytecode/rwasm.rs
+++ b/crates/primitives/src/bytecode/rwasm.rs
@@ -2,3 +2,4 @@ use alloy_primitives::{bytes, Bytes};
 
 /// Rwasm magic number in array form.
 pub static RWASM_MAGIC_BYTES: Bytes = bytes!("ef52");
+pub static WASM_MAGIC_BYTES: Bytes = bytes!("0061736d");


### PR DESCRIPTION
RWASM is executed, and WASM is deployed, so check for WASM signature is required