### PR TITLE
feat(ownable-acc): add evm compatible method to get evm code

### DIFF
--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -17,6 +17,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 workspace = true
 
 [dependencies]
+# fluentbase
+fluentbase-sdk.workspace = true
+
 # revm
 primitives.workspace = true
 


### PR DESCRIPTION
add `evm_compatible` for ownable accounts