### PR TITLE
fix: allow eip-7702 delegation to ownable account

### DIFF
--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -246,14 +246,14 @@ impl<EXT: Clone + Debug> EthFrame<EthInterpreter, EXT> {
                 .info;
             bytecode = account.code.clone().unwrap_or_default();
             code_hash = account.code_hash();
-        } else if let Bytecode::OwnableAccount(ownable_account_bytecode) = bytecode {
+        }
+        if let Bytecode::OwnableAccount(ownable_account_bytecode) = bytecode {
             let account = &ctx
                 .journal_mut()
                 .load_account_code(ownable_account_bytecode.owner_address)?
                 .info;
             bytecode = account.code.clone().unwrap_or_default();
             code_hash = account.code_hash();
-            // account owner is an execution runtime (like EVM/SVM/ERC20)
             interpreter_input.account_owner = Some(ownable_account_bytecode.owner_address);
         }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -254,6 +254,7 @@ impl<EXT: Clone + Debug> EthFrame<EthInterpreter, EXT> {
                 .info;
             bytecode = account.code.clone().unwrap_or_default();
             code_hash = account.code_hash();
+            // account owner is an execution runtime (like EVM/SVM/ERC20)
             interpreter_input.account_owner = Some(ownable_account_bytecode.owner_address);
         }
 

--- a/crates/handler/src/mainnet_builder.rs
+++ b/crates/handler/src/mainnet_builder.rs
@@ -131,4 +131,80 @@ mod test {
             StorageValue::from(1)
         );
     }
+
+    #[test]
+    fn test_eip7702_delegating_to_ownable_account() {
+        use alloy_signer::{Either, SignerSync};
+        use alloy_signer_local::PrivateKeySigner;
+        use bytecode::{
+            opcode::{PUSH1, SSTORE},
+            Bytecode,
+        };
+        use context::{Context, TxEnv};
+        use context_interface::transaction::Authorization;
+        use database::InMemoryDB;
+        use primitives::{
+            address, hardfork::SpecId, Bytes, StorageKey, StorageValue, TxKind, U256,
+        };
+        use state::AccountInfo;
+
+        let signer = PrivateKeySigner::random();
+        let ownable_account_address = address!("0x0000000000000000000000000000000000001001");
+        let final_code_address = address!("0x0000000000000000000000000000000000001002");
+
+        let auth = Authorization {
+            chain_id: U256::ZERO,
+            nonce: 0,
+            address: ownable_account_address,
+        };
+        let signature = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
+        let auth = auth.into_signed(signature);
+
+        let final_bytecode = Bytecode::new_legacy([PUSH1, 0x01, PUSH1, 0x01, SSTORE].into());
+        let ownable_bytecode = Bytecode::new_ownable_account(final_code_address, Bytes::new());
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            ownable_account_address,
+            AccountInfo::default().with_code(ownable_bytecode),
+        );
+        db.insert_account_info(
+            final_code_address,
+            AccountInfo::default().with_code(final_bytecode),
+        );
+
+        let ctx = Context::mainnet()
+            .modify_cfg_chained(|cfg| cfg.spec = SpecId::PRAGUE)
+            .with_db(db);
+
+        let mut evm = ctx.build_mainnet();
+
+        let state = evm
+            .transact(
+                TxEnv::builder()
+                    .gas_limit(100_000)
+                    .authorization_list(vec![Either::Left(auth)])
+                    .caller(address!("0x0000000000000000000000000000000000001003"))
+                    .kind(TxKind::Call(signer.address()))
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap()
+            .state;
+
+        let auth_acc = state.get(&signer.address()).unwrap();
+        assert_eq!(
+            auth_acc.info.code,
+            Some(Bytecode::new_eip7702(ownable_account_address))
+        );
+        assert_eq!(auth_acc.info.nonce, 1);
+        assert_eq!(
+            auth_acc
+                .storage
+                .get(&StorageKey::from(1))
+                .unwrap()
+                .present_value,
+            StorageValue::from(1)
+        );
+    }
 }


### PR DESCRIPTION
Context:
Veridise audit identified incorrect bytecode handling when EIP-7702 delegates to an OwnableAccount. The 'else if' prevented processing the delegation chain: EIP-7702 -> OwnableAccount -> final code.

Change:
Removed 'else' from OwnableAccount check in frame.rs:249, allowing both EIP-7702 and OwnableAccount bytecode to be processed sequentially when loading delegated code.

Rationale:
EIP-7702 may delegate to any address, including one with OwnableAccount bytecode. Sequential checks enable proper delegation chain resolution instead of early exit.

Verification:
Added test_eip7702_delegating_to_ownable_account covering the full delegation chain. Test fails with 'else if', passes after fix.

Compatibility:
Existing EIP-7702 and OwnableAccount flows unchanged. Enables new delegation pattern without breaking current behavior.