### PR TITLE
fix(handler): prevent legacy code from overwriting OwnableAccount in rwasm mode

### DIFF
--- a/bins/revme/src/cmd/statetest/runner.rs
+++ b/bins/revme/src/cmd/statetest/runner.rs
@@ -306,7 +306,7 @@ pub fn execute_test_suite(
         let cache_state = unit.state();
 
         // Setup base configuration
-        let mut cfg = CfgEnv::default();
+        let mut cfg = CfgEnv::default().disable_rwasm();
         cfg.chain_id = unit
             .env
             .current_chain_id

--- a/crates/context/interface/src/cfg.rs
+++ b/crates/context/interface/src/cfg.rs
@@ -58,6 +58,9 @@ pub trait Cfg {
 
     /// Returns whether the priority fee check is disabled.
     fn is_priority_fee_check_disabled(&self) -> bool;
+
+    /// Returns whether the rwasm used as the runtime
+    fn is_rwasm(&self) -> bool;
 }
 
 /// What bytecode analysis to perform

--- a/crates/context/src/cfg.rs
+++ b/crates/context/src/cfg.rs
@@ -55,6 +55,10 @@ pub struct CfgEnv<SPEC = SpecId> {
     /// Introduced in Osaka in [EIP-7825: Transaction Gas Limit Cap](https://eips.ethereum.org/EIPS/eip-7825)
     /// with initials cap of 30M.
     pub tx_gas_limit_cap: Option<u64>,
+
+    /// Whether the execution is for rwasm module.
+    pub is_rwasm: bool,
+
     /// A hard memory limit in bytes beyond which
     /// [OutOfGasError::Memory][context_interface::result::OutOfGasError::Memory] cannot be resized.
     ///
@@ -145,6 +149,7 @@ impl<SPEC> CfgEnv<SPEC> {
             max_blobs_per_tx: None,
             tx_gas_limit_cap: None,
             blob_base_fee_update_fraction: None,
+            is_rwasm: true,
             #[cfg(feature = "memory_limit")]
             memory_limit: (1 << 32) - 1,
             #[cfg(feature = "optional_balance_check")]
@@ -165,6 +170,11 @@ impl<SPEC> CfgEnv<SPEC> {
     /// Consumes `self` and returns a new `CfgEnv` with the specified chain ID.
     pub fn with_chain_id(mut self, chain_id: u64) -> Self {
         self.chain_id = chain_id;
+        self
+    }
+    /// Sets the rwasm flag to false.
+    pub fn disable_rwasm(mut self) -> Self {
+        self.is_rwasm = false;
         self
     }
 
@@ -192,6 +202,7 @@ impl<SPEC> CfgEnv<SPEC> {
             tx_gas_limit_cap: self.tx_gas_limit_cap,
             max_blobs_per_tx: self.max_blobs_per_tx,
             blob_base_fee_update_fraction: self.blob_base_fee_update_fraction,
+            is_rwasm: self.is_rwasm,
             #[cfg(feature = "memory_limit")]
             memory_limit: self.memory_limit,
             #[cfg(feature = "optional_balance_check")]
@@ -242,11 +253,6 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
     }
 
     #[inline]
-    fn spec(&self) -> Self::Spec {
-        self.spec
-    }
-
-    #[inline]
     fn tx_chain_id_check(&self) -> bool {
         self.tx_chain_id_check
     }
@@ -259,6 +265,11 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
             } else {
                 u64::MAX
             })
+    }
+
+    #[inline]
+    fn spec(&self) -> Self::Spec {
+        self.spec
     }
 
     #[inline]
@@ -280,20 +291,20 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
             .unwrap_or(eip3860::MAX_INITCODE_SIZE)
     }
 
-    fn is_eip3541_disabled(&self) -> bool {
+    fn is_eip3607_disabled(&self) -> bool {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "optional_eip3541")] {
-                self.disable_eip3541
+            if #[cfg(feature = "optional_eip3607")] {
+                self.disable_eip3607
             } else {
                 false
             }
         }
     }
 
-    fn is_eip3607_disabled(&self) -> bool {
+    fn is_eip3541_disabled(&self) -> bool {
         cfg_if::cfg_if! {
-            if #[cfg(feature = "optional_eip3607")] {
-                self.disable_eip3607
+            if #[cfg(feature = "optional_eip3541")] {
+                self.disable_eip3541
             } else {
                 false
             }
@@ -343,6 +354,10 @@ impl<SPEC: Into<SpecId> + Copy> Cfg for CfgEnv<SPEC> {
                 false
             }
         }
+    }
+
+    fn is_rwasm(&self) -> bool {
+        self.is_rwasm
     }
 }
 

--- a/crates/handler/src/frame.rs
+++ b/crates/handler/src/frame.rs
@@ -585,6 +585,7 @@ impl<EXT: Clone + Debug> EthFrame<EthInterpreter, EXT> {
             FrameData::Create(frame) => {
                 let max_code_size = context.cfg().max_code_size();
                 let is_eip3541_disabled = context.cfg().is_eip3541_disabled();
+                let is_rwasm = context.cfg().is_rwasm();
                 return_create(
                     context.journal_mut(),
                     self.checkpoint,
@@ -593,6 +594,7 @@ impl<EXT: Clone + Debug> EthFrame<EthInterpreter, EXT> {
                     max_code_size,
                     is_eip3541_disabled,
                     spec,
+                    is_rwasm,
                 );
 
                 ItemOrResult::Result(FrameResult::Create(CreateOutcome::new(
@@ -698,6 +700,7 @@ impl<EXT: Clone + Debug> EthFrame<EthInterpreter, EXT> {
 }
 
 /// Handles the result of a CREATE operation, including validation and state updates.
+#[allow(clippy::too_many_arguments)]
 pub fn return_create<JOURNAL: JournalTr>(
     journal: &mut JOURNAL,
     checkpoint: JournalCheckpoint,
@@ -706,6 +709,7 @@ pub fn return_create<JOURNAL: JournalTr>(
     max_code_size: usize,
     is_eip3541_disabled: bool,
     spec_id: SpecId,
+    is_rwasm: bool,
 ) {
     // If return is not ok revert and return.
     if !interpreter_result.result.is_ok() {
@@ -749,8 +753,8 @@ pub fn return_create<JOURNAL: JournalTr>(
     // If we have enough gas we can commit changes.
     journal.checkpoint_commit();
 
-    // set code only if an output result is not empty
-    if !interpreter_result.output.is_empty() {
+    // set code only if an output result is not empty and execution environment is not rwasm
+    if !is_rwasm {
         let bytecode = Bytecode::new_legacy(interpreter_result.output.clone());
         journal.set_code(address, bytecode);
     }
@@ -801,3 +805,81 @@ pub fn return_eofcreate<JOURNAL: JournalTr>(
     journal.set_code(address, Bytecode::Eof(Arc::new(bytecode)));
 }
  */
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use context::{Journal, JournalEntry};
+    use database::InMemoryDB;
+    use primitives::Address;
+    use state::Bytecode;
+
+    type TestJournal = Journal<InMemoryDB, JournalEntry>;
+
+    #[test]
+    fn test_is_rwasm_prevents_legacy_code_overwrite() {
+        let mut journal = TestJournal::new(InMemoryDB::default());
+        let output = Bytes::from_static(&[0x60, 0x80]);
+
+        // Test 1: is_rwasm=true preserves OwnableAccount
+        let addr1 = Address::from([0xAB; 20]);
+        journal.load_account(addr1).unwrap();
+        journal.set_code(
+            addr1,
+            Bytecode::new_ownable_account(Address::ZERO, Bytes::default()),
+        );
+
+        let checkpoint1 = journal.checkpoint();
+        let mut result1 = InterpreterResult {
+            result: InstructionResult::Return,
+            output: output.clone(),
+            gas: Gas::new(1_000_000),
+        };
+
+        return_create(
+            &mut journal,
+            checkpoint1,
+            &mut result1,
+            addr1,
+            0x6000,
+            false,
+            SpecId::PRAGUE,
+            true,
+        );
+
+        let account1 = journal.load_account(addr1).unwrap();
+        let code1 = account1.info.code.as_ref().unwrap();
+        assert!(
+            matches!(code1, Bytecode::OwnableAccount(_)),
+            "OwnableAccount overwritten"
+        );
+
+        // Test 2: is_rwasm=false deploys legacy
+        let addr2 = Address::from([0xCD; 20]);
+        journal.load_account(addr2).unwrap();
+
+        let checkpoint2 = journal.checkpoint();
+        let mut result2 = InterpreterResult {
+            result: InstructionResult::Return,
+            output,
+            gas: Gas::new(1_000_000),
+        };
+
+        return_create(
+            &mut journal,
+            checkpoint2,
+            &mut result2,
+            addr2,
+            0x6000,
+            false,
+            SpecId::PRAGUE,
+            false,
+        );
+
+        let account2 = journal.load_account(addr2).unwrap();
+        let code2 = account2.info.code.as_ref().unwrap();
+        assert!(
+            matches!(code2, Bytecode::LegacyAnalyzed(_)),
+            "Legacy not deployed"
+        );
+    }
+}

--- a/crates/revm/tests/integration.rs
+++ b/crates/revm/tests/integration.rs
@@ -74,6 +74,7 @@ pub fn test_multi_tx_create() {
     let mut evm = Context::mainnet()
         .modify_cfg_chained(|cfg| {
             cfg.spec = SpecId::BERLIN;
+            cfg.is_rwasm = false;
             cfg.disable_nonce_check = true;
         })
         .with_db(BenchmarkDB::new_bytecode(Bytecode::new()))


### PR DESCRIPTION
Add is_rwasm flag to CfgEnv (default true) to distinguish rwasm execution from standard EVM. Modified return_create() to skip legacy code deployment when is_rwasm=true, preserving OwnableAccount bytecode set by runtime.

Changes:
- Added is_rwasm: bool field to CfgEnv with default true
- Added is_rwasm() method to Cfg trait
- Added disable_rwasm() builder method to CfgEnv
- Modified return_create() to check is_rwasm flag before deploying code
- Added test verifying OwnableAccount preservation in rwasm mode

Fixes security issue where constructor output overwrites runtime-installed OwnableAccount bytecode, breaking delegation to rwasm execution.