### PR TITLE
chore: rename to revm-rwasm and add automated publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
           targets: riscv32imac-unknown-none-elf
       - run: |
           cargo check --target riscv32imac-unknown-none-elf --no-default-features --features=${{ matrix.features }}
-          cargo check --target riscv32imac-unknown-none-elf -p op-revm --no-default-features --features=${{ matrix.features }}
-          cargo check --target riscv32imac-unknown-none-elf -p revm-database --no-default-features
+          cargo check --target riscv32imac-unknown-none-elf -p op-revm-rwasm --no-default-features --features=${{ matrix.features }}
+          cargo check --target riscv32imac-unknown-none-elf -p revm-rwasm-database --no-default-features
 
   check:
     name: check ${{ matrix.features }}
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --no-default-features -p revm  --features=${{ matrix.features }}
+      - run: cargo check --no-default-features -p revm-rwasm  --features=${{ matrix.features }}
 
   clippy:
     name: clippy

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,45 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-release
+        run: cargo install cargo-release --locked
+
+      - name: Dry run (check which crates will be published)
+        run: |
+          cargo release publish \
+            --workspace \
+            --exclude revme \
+            --exclude custom_precompile_journal \
+            --no-confirm \
+            -v
+
+      - name: Publish crates to crates.io
+        if: success()
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo release publish \
+            --workspace \
+            --exclude revme \
+            --exclude custom_precompile_journal \
+            --no-confirm \
+            --execute

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
@@ -1389,7 +1389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1486,32 +1486,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce81edaca6167d1f78da026afa92d7ff957a80aa82a79076e11cd34cde20165"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d51e12f958551165969c6e8767e1e461729f6c1ccae923b0ba1d5cbcbbbf8"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41294c755094d2c8a514cea903039742474423f2e91601332eab5f4094f76333"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebb6f5d0df5bd0d02c63ec48e8f2e38a176b123f59e084f22caf89a0d0593e7e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1520,7 +1524,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d1a10a8a2958b68ecd261e565eef285249e242a8447ac959978319eabbb4a55"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1546,7 +1551,8 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f319986d5ae1386cfec625c70f8c01e52dc1f910aa6aaee7740bf8842d4e19c7"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1556,21 +1562,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f36e74ba4033490587a47952f74390cb7d4f1fc1fa28ace50564e491f1e38f"
 
 [[package]]
 name = "cranelift-control"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6671962c7d65b9a7ad038cd92da6784744d8a9ecf8ded8bb9a1f7046dbe2ccf"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee832f8329fa87c5df6c1d64a8506a58031e6f8a190d9b21b1900272a4dbb47d"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1580,7 +1589,8 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fce5fcf93c1fece95d0175b15fbaf0808b187430bc06c8ecde80db0ed58c5e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1591,12 +1601,14 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13fc8d838a2bf28438dbaf6ccdbc34531b6a972054f43fd23be7f124121ce6e0"
 
 [[package]]
 name = "cranelift-native"
 version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0975ce66adcf2e0729d06b1d3efea0398d793d1f39c2e0a6f52a347537836693"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1605,8 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.121.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+version = "0.121.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3d9071bc5ee5573e723d9d84a45b7025a29e8f2c5ad81b3b9d0293129541d9"
 
 [[package]]
 name = "crc"
@@ -1721,7 +1734,7 @@ name = "custom_precompile_journal"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "revm",
+ "revm-rwasm",
 ]
 
 [[package]]
@@ -2043,7 +2056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2055,7 +2068,7 @@ dependencies = [
  "alloy-provider",
  "anyhow",
  "indicatif",
- "revm",
+ "revm-rwasm",
  "tokio",
 ]
 
@@ -2064,7 +2077,7 @@ name = "example-cheatcode-inspector"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "revm",
+ "revm-rwasm",
 ]
 
 [[package]]
@@ -2072,14 +2085,14 @@ name = "example-contract-deployment"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "revm",
+ "revm-rwasm",
 ]
 
 [[package]]
 name = "example-custom-opcodes"
 version = "0.0.0"
 dependencies = [
- "revm",
+ "revm-rwasm",
 ]
 
 [[package]]
@@ -2087,7 +2100,7 @@ name = "example-database-components"
 version = "0.0.0"
 dependencies = [
  "auto_impl",
- "revm",
+ "revm-rwasm",
  "thiserror 2.0.12",
 ]
 
@@ -2098,7 +2111,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "anyhow",
- "revm",
+ "revm-rwasm",
  "tokio",
 ]
 
@@ -2106,7 +2119,7 @@ dependencies = [
 name = "example-my-evm"
 version = "0.0.0"
 dependencies = [
- "revm",
+ "revm-rwasm",
 ]
 
 [[package]]
@@ -2117,7 +2130,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "anyhow",
- "revm",
+ "revm-rwasm",
  "tokio",
 ]
 
@@ -2129,7 +2142,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "anyhow",
- "revm",
+ "revm-rwasm",
  "tokio",
 ]
 
@@ -2204,6 +2217,33 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "fluent-rwasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43b3e0bb0994c97a4bebe54b3ff78a9c5ebe47a90811c58ee3b6cca84abd0fa"
+dependencies = [
+ "bincode 2.0.1",
+ "bitvec",
+ "bytes",
+ "cfg-if",
+ "downcast-rs",
+ "fnv",
+ "hashbrown 0.15.4",
+ "libc",
+ "libm",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "serde",
+ "smallvec",
+ "spin 0.10.0",
+ "tiny-keccak",
+ "wasmi",
+ "wasmparser-nostd",
+ "wasmtime-rwasm",
 ]
 
 [[package]]
@@ -2857,7 +2897,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3376,14 +3416,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "op-revm"
+name = "op-revm-rwasm"
 version = "8.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "once_cell",
- "revm",
+ "revm-rwasm",
  "rstest",
  "serde",
  "serde_json",
@@ -3920,7 +3960,8 @@ dependencies = [
 [[package]]
 name = "pulley-interpreter"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0e8f39bc99694ce6fc8df7df7ed258d38d255a9268e2ff964f67f4a6588cdb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3931,7 +3972,8 @@ dependencies = [
 [[package]]
 name = "pulley-macros"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9276d404009cc49f3b8befeb8ffc1d868c5ea732bd9d72ab3e64231187f908c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4182,78 +4224,78 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm"
+name = "revm-rwasm"
 version = "27.0.3"
 dependencies = [
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-context",
+ "revm-rwasm-context-interface",
+ "revm-rwasm-database",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-handler",
+ "revm-rwasm-inspector",
+ "revm-rwasm-interpreter",
+ "revm-rwasm-precompile",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "revm-bytecode"
+name = "revm-rwasm-bytecode"
 version = "6.0.1"
 dependencies = [
  "bitvec",
+ "fluent-rwasm",
  "once_cell",
  "paste",
  "phf",
- "revm-primitives",
- "rwasm",
+ "revm-rwasm-primitives",
  "serde",
 ]
 
 [[package]]
-name = "revm-context"
+name = "revm-rwasm-context"
 version = "8.0.3"
 dependencies = [
  "cfg-if",
  "derive-where",
- "revm-bytecode",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-context-interface",
+ "revm-rwasm-database",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "serde",
 ]
 
 [[package]]
-name = "revm-context-interface"
+name = "revm-rwasm-context-interface"
 version = "8.0.1"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "serde",
 ]
 
 [[package]]
-name = "revm-database"
+name = "revm-rwasm-database"
 version = "7.0.1"
 dependencies = [
  "alloy-eips",
  "alloy-provider",
  "alloy-transport",
  "anyhow",
- "revm-bytecode",
- "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "rstest",
  "serde",
  "serde_json",
@@ -4261,21 +4303,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-database-interface"
+name = "revm-rwasm-database-interface"
 version = "7.0.1"
 dependencies = [
  "anyhow",
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "rstest",
  "serde",
  "tokio",
 ]
 
 [[package]]
-name = "revm-handler"
+name = "revm-rwasm-handler"
 version = "8.0.3"
 dependencies = [
  "alloy-eip7702",
@@ -4284,48 +4326,48 @@ dependencies = [
  "alloy-signer-local",
  "auto_impl",
  "derive-where",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-context",
+ "revm-rwasm-context-interface",
+ "revm-rwasm-database",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-interpreter",
+ "revm-rwasm-precompile",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "serde",
 ]
 
 [[package]]
-name = "revm-inspector"
+name = "revm-rwasm-inspector"
 version = "8.0.3"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-rwasm-context",
+ "revm-rwasm-database",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-handler",
+ "revm-rwasm-interpreter",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
  "serde",
  "serde_json",
 ]
 
 [[package]]
-name = "revm-interpreter"
+name = "revm-rwasm-interpreter"
 version = "23.0.2"
 dependencies = [
  "bincode 2.0.1",
- "revm-bytecode",
- "revm-context-interface",
- "revm-primitives",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-context-interface",
+ "revm-rwasm-primitives",
  "serde",
 ]
 
 [[package]]
-name = "revm-precompile"
+name = "revm-rwasm-precompile"
 version = "24.0.1"
 dependencies = [
  "ark-bls12-381",
@@ -4346,7 +4388,7 @@ dependencies = [
  "once_cell",
  "p256",
  "rand 0.9.1",
- "revm-primitives",
+ "revm-rwasm-primitives",
  "ripemd",
  "rstest",
  "rug",
@@ -4356,7 +4398,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-primitives"
+name = "revm-rwasm-primitives"
 version = "20.0.0"
 dependencies = [
  "alloy-primitives",
@@ -4365,21 +4407,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-state"
+name = "revm-rwasm-state"
 version = "7.0.1"
 dependencies = [
  "bitflags",
- "revm-bytecode",
- "revm-primitives",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-primitives",
  "serde",
 ]
 
 [[package]]
-name = "revm-statetest-types"
+name = "revm-rwasm-statetest-types"
 version = "8.0.4"
 dependencies = [
  "k256",
- "revm",
+ "revm-rwasm",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4398,16 +4440,16 @@ dependencies = [
  "indicatif",
  "k256",
  "plain_hasher",
- "revm",
- "revm-bytecode",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-inspector",
- "revm-primitives",
- "revm-state",
- "revm-statetest-types",
+ "revm-rwasm",
+ "revm-rwasm-bytecode",
+ "revm-rwasm-context",
+ "revm-rwasm-context-interface",
+ "revm-rwasm-database",
+ "revm-rwasm-database-interface",
+ "revm-rwasm-inspector",
+ "revm-rwasm-primitives",
+ "revm-rwasm-state",
+ "revm-rwasm-statetest-types",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4575,7 +4617,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4603,29 +4645,6 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
-]
-
-[[package]]
-name = "rwasm"
-version = "0.0.0"
-source = "git+https://github.com/fluentlabs-xyz/rwasm?branch=devel#bf9f1bf5c13bcd157aa99f3a6bde968649712c52"
-dependencies = [
- "bincode 2.0.1",
- "bitvec",
- "bytes",
- "downcast-rs",
- "hashbrown 0.15.4",
- "libm",
- "num-derive",
- "num-traits",
- "paste",
- "serde",
- "smallvec",
- "spin 0.10.0",
- "tiny-keccak",
- "wasmi",
- "wasmparser-nostd",
- "wasmtime",
 ]
 
 [[package]]
@@ -5177,7 +5196,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5866,9 +5885,162 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime"
+name = "wasmtime-asm-macros"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c45ecc343d3ad4629d5882e94f3b0f0fac22a043c07e64373381168ae00c259"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-cache"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb1976337108c8b9f80b05e9b909bf603f85c4ea97e31c112876a36d3cdcb98"
+dependencies = [
+ "anyhow",
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3491c0f2511be561a92ac9b086351abc3a0f48c5f5f7d14f3975e246c13838be"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bc084e249f74e61c79077d8937c34fb0af223752b9b1725e3d7ed94b006f23"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0010bd93362c634837e6bb13e213c2d83673b28dc12208b64ddd821fa55f7d33"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser 0.233.0",
+ "wasmtime-environ",
+ "wasmtime-math",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36a035dc308ff6be3d790dafdc2e41a128415e20ad864580da49470073e21dc1"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.9.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver 1.0.26",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.233.0",
+ "wasmparser 0.233.0",
+ "wasmprinter",
+ "wasmtime-component-util",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc3c1e4e70cdd3a4572dff79062caa48988f7f1ccf6850d98a4e4c41bf3cfc8"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-jit-debug"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d83fa2dea686f76b5437b66045aae6351d359ee11cc4124f9842de63837b81"
+dependencies = [
+ "cc",
+ "object",
+ "rustix",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c71d64e8ebe132cd45e9d299a4d0daf261d66bd05cf50a204a1bf8cf96ff1f"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-math"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222bfa4769c6931c985711eb49a92748ea0acc4ca85fcd24e945a2f1bacda0c1"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-rwasm"
+version = "34.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2a7abdccb3ea676c977e0bb4757de6a765c98d3c2baf703be9b8fd2a0ec170"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -5907,12 +6079,12 @@ dependencies = [
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
- "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-math",
+ "wasmtime-rwasm-cranelift",
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
  "wasmtime-winch",
@@ -5921,55 +6093,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
+name = "wasmtime-rwasm-cranelift"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-cache"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "anyhow",
- "base64",
- "directories-next",
- "log",
- "postcard",
- "rustix",
- "serde",
- "serde_derive",
- "sha2 0.10.9",
- "toml",
- "windows-sys 0.59.0",
- "zstd",
-]
-
-[[package]]
-name = "wasmtime-component-macro"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-
-[[package]]
-name = "wasmtime-cranelift"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "477548a15bd19bf151b292b9c97060e42f17aa24b3d9fbc3da36a0b400c3405e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -5993,85 +6120,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "anyhow",
- "cpp_demangle",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap 2.9.0",
- "log",
- "object",
- "postcard",
- "rustc-demangle",
- "semver 1.0.26",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.233.0",
- "wasmparser 0.233.0",
- "wasmprinter",
- "wasmtime-component-util",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "libc",
- "rustix",
- "wasmtime-asm-macros",
- "wasmtime-versioned-export-macros",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-jit-debug"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "cc",
- "object",
- "rustix",
- "wasmtime-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wasmtime-math"
-version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "wasmtime-slab"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac42c7fb0639f7c3e0c1ed0c984050245c55410f3fae334dd5b102e0edfab14"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e052e1d9c30b8f31aff64380caaaff492a9890a412658bcc8866fe626b8e91f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6081,7 +6139,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-winch"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d71e002033124221f6633a462c26067280519fdd7527ba2751f585db779cc6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -6097,7 +6156,8 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f967f5efaaac7694e6bd0d67542a5a036830860e4adf95684260181e85a5d299"
 dependencies = [
  "anyhow",
  "heck",
@@ -6183,7 +6243,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6195,7 +6255,8 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "winch-codegen"
 version = "34.0.1"
-source = "git+https://github.com/fluentlabs-xyz/wasmtime?branch=devel#f0c5b017d2b7d59c84999123338da7634ab0cf1f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2bf456780101aff8950642fdf984f182816d7f555d5375699200242be78762"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,20 +36,20 @@ default-members = ["crates/revm"]
 
 [workspace.dependencies]
 # revm
-revm = { path = "crates/revm", version = "27.0.3", default-features = false }
-primitives = { path = "crates/primitives", package = "revm-primitives", version = "20.0.0", default-features = false }
-bytecode = { path = "crates/bytecode", package = "revm-bytecode", version = "6.0.1", default-features = false }
-database = { path = "crates/database", package = "revm-database", version = "7.0.1", default-features = false }
-database-interface = { path = "crates/database/interface", package = "revm-database-interface", version = "7.0.1", default-features = false }
-state = { path = "crates/state", package = "revm-state", version = "7.0.1", default-features = false }
-interpreter = { path = "crates/interpreter", package = "revm-interpreter", version = "23.0.2", default-features = false }
-inspector = { path = "crates/inspector", package = "revm-inspector", version = "8.0.3", default-features = false }
-precompile = { path = "crates/precompile", package = "revm-precompile", version = "24.0.1", default-features = false }
-statetest-types = { path = "crates/statetest-types", package = "revm-statetest-types", version = "8.0.4", default-features = false }
-context = { path = "crates/context", package = "revm-context", version = "8.0.3", default-features = false }
-context-interface = { path = "crates/context/interface", package = "revm-context-interface", version = "8.0.1", default-features = false }
-handler = { path = "crates/handler", package = "revm-handler", version = "8.0.3", default-features = false }
-op-revm = { path = "crates/op-revm", package = "op-revm", version = "8.0.3", default-features = false }
+revm = { path = "crates/revm", package = "revm-rwasm", version = "27.0.3", default-features = false }
+primitives = { path = "crates/primitives", package = "revm-rwasm-primitives", version = "20.0.0", default-features = false }
+bytecode = { path = "crates/bytecode", package = "revm-rwasm-bytecode", version = "6.0.1", default-features = false }
+database = { path = "crates/database", package = "revm-rwasm-database", version = "7.0.1", default-features = false }
+database-interface = { path = "crates/database/interface", package = "revm-rwasm-database-interface", version = "7.0.1", default-features = false }
+state = { path = "crates/state", package = "revm-rwasm-state", version = "7.0.1", default-features = false }
+interpreter = { path = "crates/interpreter", package = "revm-rwasm-interpreter", version = "23.0.2", default-features = false }
+inspector = { path = "crates/inspector", package = "revm-rwasm-inspector", version = "8.0.3", default-features = false }
+precompile = { path = "crates/precompile", package = "revm-rwasm-precompile", version = "24.0.1", default-features = false }
+statetest-types = { path = "crates/statetest-types", package = "revm-rwasm-statetest-types", version = "8.0.4", default-features = false }
+context = { path = "crates/context", package = "revm-rwasm-context", version = "8.0.3", default-features = false }
+context-interface = { path = "crates/context/interface", package = "revm-rwasm-context-interface", version = "8.0.1", default-features = false }
+handler = { path = "crates/handler", package = "revm-rwasm-handler", version = "8.0.3", default-features = false }
+op-revm = { path = "crates/op-revm", package = "op-revm-rwasm", version = "8.0.3", default-features = false }
 
 # alloy
 alloy-eip2930 = { version = "0.2.1", default-features = false }
@@ -125,16 +125,18 @@ triehash = "0.8"
 walkdir = "2.5"
 
 # rwasm
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm", branch = "devel", default-features = false }
+rwasm = { version = "0.1.0", package = "fluent-rwasm", default-features = false }
 #rwasm = { path = "../../../rwasm", default-features = false }
 
 [workspace.package]
 license = "MIT"
-authors = ["Dragan Rakita <dragan0rakita@gmail.com>"]
+authors = [
+    "Dmitry Savonin <dmitry@fluentlabs.xyz>",
+]
 categories = ["no-std", "compilers", "cryptography::cryptocurrencies"]
 keywords = ["revm", "evm", "ethereum", "blockchain", "no_std"]
-repository = "https://github.com/bluealloy/revm"
-documentation = "https://bluealloy.github.io/revm/"
+repository = "https://github.com/fluentlabs-xyz/revm-rwasm"
+documentation = ""
 homepage = ""
 edition = "2021"
 

--- a/crates/bytecode/Cargo.toml
+++ b/crates/bytecode/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-bytecode"
+name = "revm-rwasm-bytecode"
 description = "EVM Bytecodes"
 version = "6.0.1"
 authors.workspace = true

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-context"
+name = "revm-rwasm-context"
 description = "Revm context crates"
 version = "8.0.3"
 authors.workspace = true

--- a/crates/context/interface/Cargo.toml
+++ b/crates/context/interface/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-context-interface"
+name = "revm-rwasm-context-interface"
 description = "Revm context interface crates"
 version = "8.0.1"
 authors.workspace = true

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-database"
+name = "revm-rwasm-database"
 description = "Revm Database implementations"
 version = "7.0.1"
 authors.workspace = true

--- a/crates/database/interface/Cargo.toml
+++ b/crates/database/interface/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-database-interface"
+name = "revm-rwasm-database-interface"
 description = "Revm Database interface"
 version = "7.0.1"
 authors.workspace = true

--- a/crates/handler/Cargo.toml
+++ b/crates/handler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-handler"
+name = "revm-rwasm-handler"
 description = "Revm handler crates"
 version = "8.0.3"
 authors.workspace = true

--- a/crates/inspector/Cargo.toml
+++ b/crates/inspector/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-inspector"
+name = "revm-rwasm-inspector"
 description = "Revm inspector interface"
 version = "8.0.3"
 authors.workspace = true

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-interpreter"
+name = "revm-rwasm-interpreter"
 description = "Revm Interpreter that executes bytecode."
 version = "23.0.2"
 authors.workspace = true

--- a/crates/op-revm/Cargo.toml
+++ b/crates/op-revm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "op-revm"
+name = "op-revm-rwasm"
 description = "Optimism variant of Revm"
 version = "8.0.3"
 authors.workspace = true

--- a/crates/op-revm/tests/integration.rs
+++ b/crates/op-revm/tests/integration.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use common::compare_or_save_testdata;
-use op_revm::{
+use op_revm_rwasm::{
     precompiles::bn128_pair::GRANITE_MAX_INPUT_SIZE, DefaultOp, L1BlockInfo, OpBuilder,
     OpHaltReason, OpSpecId, OpTransaction,
 };

--- a/crates/precompile/Cargo.toml
+++ b/crates/precompile/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-precompile"
+name = "revm-rwasm-precompile"
 description = "Revm Precompiles - Ethereum compatible precompiled contracts"
 version = "24.0.1"
 authors.workspace = true

--- a/crates/precompile/bench/ecrecover.rs
+++ b/crates/precompile/bench/ecrecover.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for the ecrecover precompile
 use criterion::{measurement::Measurement, BenchmarkGroup};
 use primitives::{hex, keccak256, Bytes, U256};
-use revm_precompile::secp256k1::ec_recover_run;
+use revm_rwasm_precompile::secp256k1::ec_recover_run;
 use secp256k1::{Message, SecretKey, SECP256K1};
 
 /// Add benches for the ecrecover precompile

--- a/crates/precompile/bench/eip1962.rs
+++ b/crates/precompile/bench/eip1962.rs
@@ -2,7 +2,7 @@
 use criterion::{measurement::Measurement, BenchmarkGroup};
 use primitives::hex;
 use primitives::Bytes;
-use revm_precompile::bn128::{
+use revm_rwasm_precompile::bn128::{
     add::ISTANBUL_ADD_GAS_COST,
     mul::ISTANBUL_MUL_GAS_COST,
     pair::{ISTANBUL_PAIR_BASE, ISTANBUL_PAIR_PER_POINT},

--- a/crates/precompile/bench/eip2537.rs
+++ b/crates/precompile/bench/eip2537.rs
@@ -5,7 +5,9 @@ use ark_std::rand::{rngs::StdRng, SeedableRng};
 use arkworks_general::{encode_base_field, encode_field_32_bytes, random_field, random_points};
 use criterion::{measurement::Measurement, BenchmarkGroup};
 use primitives::Bytes;
-use revm_precompile::bls12_381_const::{PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH};
+use revm_rwasm_precompile::bls12_381_const::{
+    PADDED_FP_LENGTH, PADDED_G1_LENGTH, PADDED_G2_LENGTH,
+};
 
 const RNG_SEED: u64 = 42;
 const MAX_MSM_SIZE: usize = 256;
@@ -20,7 +22,7 @@ mod arkworks_general {
     use ark_ff::Field;
 
     use ark_serialize::CanonicalSerialize;
-    use revm_precompile::bls12_381_const::{FP_LENGTH, FP_PAD_BY, PADDED_FP_LENGTH};
+    use revm_rwasm_precompile::bls12_381_const::{FP_LENGTH, FP_PAD_BY, PADDED_FP_LENGTH};
 
     pub(super) fn random_points<P: AffineRepr>(num_points: usize, rng: &mut StdRng) -> Vec<P> {
         let mut points = Vec::new();
@@ -143,7 +145,7 @@ fn g2_add_test_vectors(num_test_vectors: usize, rng: &mut StdRng) -> Vec<Precomp
 
 /// Add benches for the BLS12-381 G1 add precompile
 pub fn add_g1_add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::g1_add::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::g1_add::PRECOMPILE;
 
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     let test_vectors = g1_add_test_vectors(1, &mut rng);
@@ -158,7 +160,7 @@ pub fn add_g1_add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
 /// Add benches for the BLS12-381 G2 add precompile
 pub fn add_g2_add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::g2_add::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::g2_add::PRECOMPILE;
 
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     let test_vectors = g2_add_test_vectors(1, &mut rng);
@@ -173,7 +175,7 @@ pub fn add_g2_add_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
 
 /// Add benches for the BLS12-381 G1 msm precompile
 pub fn add_g1_msm_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::g1_msm::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::g1_msm::PRECOMPILE;
 
     let precompile = *PRECOMPILE.precompile();
 
@@ -218,7 +220,7 @@ fn g2_msm_test_vectors(msm_size: usize, rng: &mut StdRng) -> PrecompileInput {
 
 /// Add benches for the BLS12-381 G2 msm precompile
 pub fn add_g2_msm_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::g2_msm::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::g2_msm::PRECOMPILE;
 
     let precompile = *PRECOMPILE.precompile();
 
@@ -251,7 +253,7 @@ fn pairing_test_vectors(num_pairs: usize, rng: &mut StdRng) -> PrecompileInput {
 
 /// Add benches for the BLS12-381 pairing precompile
 pub fn add_pairing_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::pairing::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::pairing::PRECOMPILE;
 
     let precompile = *PRECOMPILE.precompile();
 
@@ -275,7 +277,7 @@ fn map_fp_to_g1_test_vectors(rng: &mut StdRng) -> PrecompileInput {
 
 /// Add benches for the BLS12-381 map fp to g1 precompiles
 pub fn add_map_fp_to_g1_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::map_fp_to_g1::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::map_fp_to_g1::PRECOMPILE;
 
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     let test_vector = map_fp_to_g1_test_vectors(&mut rng);
@@ -302,7 +304,7 @@ fn map_fp2_to_g2_test_vectors(rng: &mut StdRng) -> PrecompileInput {
 
 /// Add benches for the BLS12-381 map fp2 to g2 precompiles
 pub fn add_map_fp2_to_g2_benches<M: Measurement>(group: &mut BenchmarkGroup<'_, M>) {
-    use revm_precompile::bls12_381::map_fp2_to_g2::PRECOMPILE;
+    use revm_rwasm_precompile::bls12_381::map_fp2_to_g2::PRECOMPILE;
 
     let mut rng = StdRng::seed_from_u64(RNG_SEED);
     let test_vector = map_fp2_to_g2_test_vectors(&mut rng);

--- a/crates/precompile/bench/eip4844.rs
+++ b/crates/precompile/bench/eip4844.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for the KZG point evaluation precompile
 use criterion::{measurement::Measurement, BenchmarkGroup};
 use primitives::{eip4844::VERSIONED_HASH_VERSION_KZG, hex};
-use revm_precompile::kzg_point_evaluation::run;
+use revm_rwasm_precompile::kzg_point_evaluation::run;
 use sha2::{Digest, Sha256};
 
 /// Add benches for the KZG point evaluation precompile

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-primitives"
+name = "revm-rwasm-primitives"
 description = "Revm primitives types"
 version = "20.0.0"
 authors.workspace = true

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm"
+name = "revm-rwasm"
 description = "Revm - Rust Ethereum Virtual Machine"
 version = "27.0.3"
 authors.workspace = true

--- a/crates/revm/tests/common.rs
+++ b/crates/revm/tests/common.rs
@@ -1,7 +1,7 @@
 //! Common test utilities used to compare execution results against testdata.
 #![allow(dead_code)]
 
-use revm::{
+use revm_rwasm::{
     context::result::ResultAndState,
     context_interface::result::{ExecutionResult, HaltReason, Output, SuccessReason},
     primitives::Bytes,

--- a/crates/revm/tests/integration.rs
+++ b/crates/revm/tests/integration.rs
@@ -5,7 +5,7 @@ use common::compare_or_save_testdata;
 use context::ContextTr;
 use database::BENCH_CALLER;
 use primitives::{address, b256, hardfork::SpecId, Bytes, TxKind, KECCAK_EMPTY};
-use revm::{
+use revm_rwasm::{
     bytecode::opcode,
     context::TxEnv,
     database::{BenchmarkDB, BENCH_TARGET},

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-state"
+name = "revm-rwasm-state"
 description = "Revm state types"
 version = "7.0.1"
 authors.workspace = true

--- a/crates/statetest-types/Cargo.toml
+++ b/crates/statetest-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "revm-statetest-types"
+name = "revm-rwasm-statetest-types"
 description = "Statetest types for revme"
 version = "8.0.4"
 authors.workspace = true

--- a/examples/custom_precompile_journal/Cargo.toml
+++ b/examples/custom_precompile_journal/Cargo.toml
@@ -8,5 +8,5 @@ name = "custom_precompile_journal"
 path = "src/main.rs"
 
 [dependencies]
-revm = { path = "../../crates/revm", features = ["optional_eip3607"] }
+revm = { package = "revm-rwasm", path = "../../crates/revm", features = ["optional_eip3607"] }
 anyhow = "1.0"


### PR DESCRIPTION
Rename packages to revm-rwasm namespace for crates.io publication and add CI workflow for automated releases.

Changes:
- Rename all revm-* packages to revm-rwasm-* namespace
- Update all import paths and package references across workspace
- Add GitHub Actions workflow for automated crates.io publishing
- Update CI checks to use renamed packages
- Switch rwasm dependencies from git to crates.io versions