### PR TITLE
fix: extend rwasm halt reason mapping

### DIFF
--- a/crates/context/interface/src/result.rs
+++ b/crates/context/interface/src/result.rs
@@ -15,9 +15,93 @@ use state::EvmState;
 use std::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 
 /// Trait for the halt reason.
-pub trait HaltReasonTr: Clone + Debug + PartialEq + Eq + From<HaltReason> {}
+///
+/// Implementors can extend the base EVM halt reason space with chain/runtime-specific reasons.
+/// The default hooks collapse non-EVM runtime failures into [`HaltReason::PrecompileErrorWithContext`]
+/// so base EVM users do not need to carry Fluent/rWasm-specific variants.
+pub trait HaltReasonTr: Clone + Debug + PartialEq + Eq + From<HaltReason> {
+    /// Function can only be invoked as the root entry call.
+    fn root_call_only() -> Self {
+        HaltReason::PrecompileErrorWithContext("RootCallOnly".into()).into()
+    }
 
-impl<T> HaltReasonTr for T where T: Clone + Debug + PartialEq + Eq + From<HaltReason> {}
+    /// Builtin function received malformed or invalid parameters.
+    fn malformed_builtin_params() -> Self {
+        HaltReason::PrecompileErrorWithContext("MalformedBuiltinParams".into()).into()
+    }
+
+    /// Exceeded maximum allowed call stack depth.
+    fn call_depth_overflow() -> Self {
+        HaltReason::CallTooDeep.into()
+    }
+
+    /// Exit code must be negative, but a non-negative value was used.
+    fn non_negative_exit_code() -> Self {
+        HaltReason::PrecompileErrorWithContext("NonNegativeExitCode".into()).into()
+    }
+
+    /// Generic catch-all error for unknown failures.
+    fn unknown_error() -> Self {
+        HaltReason::PrecompileErrorWithContext("UnknownError".into()).into()
+    }
+
+    /// I/O operation tried to read/write outside allowed buffer bounds.
+    fn input_output_out_of_bounds() -> Self {
+        HaltReason::OutOfOffset.into()
+    }
+
+    /// Execution reached a code path marked as unreachable.
+    fn unreachable_code_reached() -> Self {
+        HaltReason::PrecompileErrorWithContext("UnreachableCodeReached".into()).into()
+    }
+
+    /// Memory access outside the allocated memory range.
+    fn memory_out_of_bounds() -> Self {
+        HaltReason::PrecompileErrorWithContext("MemoryOutOfBounds".into()).into()
+    }
+
+    /// Table index access outside the allocated table range.
+    fn table_out_of_bounds() -> Self {
+        HaltReason::PrecompileErrorWithContext("TableOutOfBounds".into()).into()
+    }
+
+    /// Indirect function call attempted with a null function reference.
+    fn indirect_call_to_null() -> Self {
+        HaltReason::PrecompileErrorWithContext("IndirectCallToNull".into()).into()
+    }
+
+    /// Division or remainder by zero occurred.
+    fn integer_division_by_zero() -> Self {
+        HaltReason::PrecompileErrorWithContext("IntegerDivisionByZero".into()).into()
+    }
+
+    /// Integer arithmetic operation overflowed the allowed range.
+    fn integer_overflow() -> Self {
+        HaltReason::OverflowPayment.into()
+    }
+
+    /// Invalid conversion to integer.
+    fn bad_conversion_to_integer() -> Self {
+        HaltReason::PrecompileErrorWithContext("BadConversionToInteger".into()).into()
+    }
+
+    /// Function signature mismatch in a call.
+    fn bad_signature() -> Self {
+        HaltReason::PrecompileErrorWithContext("BadSignature".into()).into()
+    }
+
+    /// Execution ran out of allocated fuel/gas.
+    fn out_of_fuel() -> Self {
+        HaltReason::OutOfGas(OutOfGasError::Basic).into()
+    }
+
+    /// Call an undefined or unregistered external function.
+    fn unknown_external_function() -> Self {
+        HaltReason::PrecompileErrorWithContext("UnknownExternalFunction".into()).into()
+    }
+}
+
+impl HaltReasonTr for HaltReason {}
 
 /// Tuple containing evm execution result and state.s
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -704,40 +788,6 @@ pub enum HaltReason {
     OutOfFunds,
     /// Call is too deep.
     CallTooDeep,
-
-    /* Fluentbase Halts produced by rWasm VM runtime */
-    /// Function can only be invoked as the root entry call
-    RootCallOnly,
-    /// Builtin function received malformed or invalid parameters
-    MalformedBuiltinParams,
-    /// Exceeded maximum allowed call stack depth
-    CallDepthOverflow,
-    /// Exit code must be non-negative, but a negative value was used
-    NonNegativeExitCode,
-    /// Generic catch-all error for unknown failures
-    UnknownError,
-    /// I/O operation tried to read/write outside allowed buffer bounds
-    InputOutputOutOfBounds,
-    /// Execution reached a code path marked as unreachable
-    UnreachableCodeReached,
-    /// Memory access outside the allocated memory range
-    MemoryOutOfBounds,
-    /// Table index access outside the allocated table range
-    TableOutOfBounds,
-    /// Indirect function call attempted with a null function reference
-    IndirectCallToNull,
-    /// Division or remainder by zero occurred
-    IntegerDivisionByZero,
-    /// Integer arithmetic operation overflowed the allowed range
-    IntegerOverflow,
-    /// Invalid conversion to integer (e.g., from NaN or out-of-range value)
-    BadConversionToInteger,
-    /// Function signature mismatch in a call
-    BadSignature,
-    /// Execution ran out of allocated fuel/gas
-    OutOfFuel,
-    /// Call an undefined or unregistered external function
-    UnknownExternalFunction,
 }
 
 impl core::error::Error for HaltReason {}
@@ -767,22 +817,6 @@ impl fmt::Display for HaltReason {
             Self::CallNotAllowedInsideStatic => write!(f, "call not allowed inside static call"),
             Self::OutOfFunds => write!(f, "out of funds"),
             Self::CallTooDeep => write!(f, "call too deep"),
-            Self::RootCallOnly => write!(f, "root call only"),
-            Self::MalformedBuiltinParams => write!(f, "malformed builtin params"),
-            Self::CallDepthOverflow => write!(f, "call depth overflow"),
-            Self::NonNegativeExitCode => write!(f, "non negative exit code"),
-            Self::UnknownError => write!(f, "unknown error"),
-            Self::InputOutputOutOfBounds => write!(f, "input output out of bounds"),
-            Self::UnreachableCodeReached => write!(f, "unreachable code reached"),
-            Self::MemoryOutOfBounds => write!(f, "memory out of bounds"),
-            Self::TableOutOfBounds => write!(f, "table out of bounds"),
-            Self::IndirectCallToNull => write!(f, "indirect call to null"),
-            Self::IntegerDivisionByZero => write!(f, "integer division by zero"),
-            Self::IntegerOverflow => write!(f, "integer overflow"),
-            Self::BadConversionToInteger => write!(f, "bad conversion to integer"),
-            Self::BadSignature => write!(f, "bad signature"),
-            Self::OutOfFuel => write!(f, "out of fuel"),
-            Self::UnknownExternalFunction => write!(f, "unknown external function"),
         }
     }
 }

--- a/crates/interpreter/src/instruction_result.rs
+++ b/crates/interpreter/src/instruction_result.rs
@@ -1,6 +1,6 @@
 use context_interface::{
     journaled_state::TransferError,
-    result::{HaltReason, OutOfGasError, SuccessReason},
+    result::{HaltReason, HaltReasonTr, OutOfGasError, SuccessReason},
 };
 use core::fmt::Debug;
 
@@ -169,24 +169,6 @@ impl From<HaltReason> for InstructionResult {
             HaltReason::CallNotAllowedInsideStatic => Self::CallNotAllowedInsideStatic,
             HaltReason::OutOfFunds => Self::OutOfFunds,
             HaltReason::CallTooDeep => Self::CallTooDeep,
-
-            // Fluentbase error codes
-            HaltReason::RootCallOnly => Self::RootCallOnly,
-            HaltReason::MalformedBuiltinParams => Self::MalformedBuiltinParams,
-            HaltReason::CallDepthOverflow => Self::CallDepthOverflow,
-            HaltReason::NonNegativeExitCode => Self::NonNegativeExitCode,
-            HaltReason::UnknownError => Self::UnknownError,
-            HaltReason::InputOutputOutOfBounds => Self::InputOutputOutOfBounds,
-            HaltReason::UnreachableCodeReached => Self::UnreachableCodeReached,
-            HaltReason::MemoryOutOfBounds => Self::MemoryOutOfBounds,
-            HaltReason::TableOutOfBounds => Self::TableOutOfBounds,
-            HaltReason::IndirectCallToNull => Self::IndirectCallToNull,
-            HaltReason::IntegerDivisionByZero => Self::IntegerDivisionByZero,
-            HaltReason::IntegerOverflow => Self::IntegerOverflow,
-            HaltReason::BadConversionToInteger => Self::BadConversionToInteger,
-            HaltReason::BadSignature => Self::BadSignature,
-            HaltReason::OutOfFuel => Self::OutOfFuel,
-            HaltReason::UnknownExternalFunction => Self::UnknownExternalFunction,
         }
     }
 }
@@ -358,7 +340,7 @@ impl<HALT: From<HaltReason>> From<HaltReason> for SuccessOrHalt<HALT> {
     }
 }
 
-impl<HaltReasonTr: From<HaltReason>> From<InstructionResult> for SuccessOrHalt<HaltReasonTr> {
+impl<HALT: HaltReasonTr> From<InstructionResult> for SuccessOrHalt<HALT> {
     fn from(result: InstructionResult) -> Self {
         match result {
             InstructionResult::Stop => Self::Success(SuccessReason::Stop),
@@ -418,42 +400,35 @@ impl<HaltReasonTr: From<HaltReason>> From<InstructionResult> for SuccessOrHalt<H
             InstructionResult::InvalidExtDelegateCallTarget => {
                 Self::Internal(InternalResult::InvalidExtDelegateCallTarget)
             }
-            // Fluentbase error codes
-            InstructionResult::RootCallOnly => Self::Halt(HaltReason::RootCallOnly.into()),
+            // Fluent/rWasm runtime errors are mapped through the generic halt reason
+            // extension point instead of being embedded into base EVM HaltReason.
+            InstructionResult::RootCallOnly => Self::Halt(HALT::root_call_only()),
             InstructionResult::MalformedBuiltinParams => {
-                Self::Halt(HaltReason::MalformedBuiltinParams.into())
+                Self::Halt(HALT::malformed_builtin_params())
             }
-            InstructionResult::CallDepthOverflow => {
-                Self::Halt(HaltReason::CallDepthOverflow.into())
-            }
-            InstructionResult::NonNegativeExitCode => {
-                Self::Halt(HaltReason::NonNegativeExitCode.into())
-            }
-            InstructionResult::UnknownError => Self::Halt(HaltReason::UnknownError.into()),
+            InstructionResult::CallDepthOverflow => Self::Halt(HALT::call_depth_overflow()),
+            InstructionResult::NonNegativeExitCode => Self::Halt(HALT::non_negative_exit_code()),
+            InstructionResult::UnknownError => Self::Halt(HALT::unknown_error()),
             InstructionResult::InputOutputOutOfBounds => {
-                Self::Halt(HaltReason::InputOutputOutOfBounds.into())
+                Self::Halt(HALT::input_output_out_of_bounds())
             }
             InstructionResult::UnreachableCodeReached => {
-                Self::Halt(HaltReason::UnreachableCodeReached.into())
+                Self::Halt(HALT::unreachable_code_reached())
             }
-            InstructionResult::MemoryOutOfBounds => {
-                Self::Halt(HaltReason::MemoryOutOfBounds.into())
-            }
-            InstructionResult::TableOutOfBounds => Self::Halt(HaltReason::TableOutOfBounds.into()),
-            InstructionResult::IndirectCallToNull => {
-                Self::Halt(HaltReason::IndirectCallToNull.into())
-            }
+            InstructionResult::MemoryOutOfBounds => Self::Halt(HALT::memory_out_of_bounds()),
+            InstructionResult::TableOutOfBounds => Self::Halt(HALT::table_out_of_bounds()),
+            InstructionResult::IndirectCallToNull => Self::Halt(HALT::indirect_call_to_null()),
             InstructionResult::IntegerDivisionByZero => {
-                Self::Halt(HaltReason::IntegerDivisionByZero.into())
+                Self::Halt(HALT::integer_division_by_zero())
             }
-            InstructionResult::IntegerOverflow => Self::Halt(HaltReason::IntegerOverflow.into()),
+            InstructionResult::IntegerOverflow => Self::Halt(HALT::integer_overflow()),
             InstructionResult::BadConversionToInteger => {
-                Self::Halt(HaltReason::BadConversionToInteger.into())
+                Self::Halt(HALT::bad_conversion_to_integer())
             }
-            InstructionResult::BadSignature => Self::Halt(HaltReason::BadSignature.into()),
-            InstructionResult::OutOfFuel => Self::Halt(HaltReason::OutOfFuel.into()),
+            InstructionResult::BadSignature => Self::Halt(HALT::bad_signature()),
+            InstructionResult::OutOfFuel => Self::Halt(HALT::out_of_fuel()),
             InstructionResult::UnknownExternalFunction => {
-                Self::Halt(HaltReason::UnknownExternalFunction.into())
+                Self::Halt(HALT::unknown_external_function())
             }
         }
     }
@@ -461,7 +436,31 @@ impl<HaltReasonTr: From<HaltReason>> From<InstructionResult> for SuccessOrHalt<H
 
 #[cfg(test)]
 mod tests {
-    use crate::InstructionResult;
+    use crate::{InstructionResult, SuccessOrHalt};
+    use context_interface::result::{HaltReason, HaltReasonTr, OutOfGasError};
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum TestHaltReason {
+        Base(HaltReason),
+        RootCallOnly,
+        OutOfFuel,
+    }
+
+    impl From<HaltReason> for TestHaltReason {
+        fn from(value: HaltReason) -> Self {
+            Self::Base(value)
+        }
+    }
+
+    impl HaltReasonTr for TestHaltReason {
+        fn root_call_only() -> Self {
+            Self::RootCallOnly
+        }
+
+        fn out_of_fuel() -> Self {
+            Self::OutOfFuel
+        }
+    }
 
     #[test]
     fn exhaustiveness() {
@@ -525,5 +524,31 @@ mod tests {
             assert!(!result.is_revert());
             assert!(result.is_error());
         }
+    }
+
+    #[test]
+    fn runtime_halt_results_use_extension_hooks() {
+        assert_eq!(
+            SuccessOrHalt::<TestHaltReason>::from(InstructionResult::RootCallOnly),
+            SuccessOrHalt::Halt(TestHaltReason::RootCallOnly)
+        );
+        assert_eq!(
+            SuccessOrHalt::<TestHaltReason>::from(InstructionResult::OutOfFuel),
+            SuccessOrHalt::Halt(TestHaltReason::OutOfFuel)
+        );
+    }
+
+    #[test]
+    fn base_halt_reason_collapses_runtime_halts() {
+        assert_eq!(
+            SuccessOrHalt::<HaltReason>::from(InstructionResult::RootCallOnly),
+            SuccessOrHalt::Halt(HaltReason::PrecompileErrorWithContext(
+                "RootCallOnly".into()
+            ))
+        );
+        assert_eq!(
+            SuccessOrHalt::<HaltReason>::from(InstructionResult::OutOfFuel),
+            SuccessOrHalt::Halt(HaltReason::OutOfGas(OutOfGasError::Basic))
+        );
     }
 }

--- a/crates/interpreter/src/interpreter_action.rs
+++ b/crates/interpreter/src/interpreter_action.rs
@@ -7,7 +7,7 @@ pub use call_inputs::{CallInput, CallInputs, CallScheme, CallValue};
 pub use call_outcome::CallOutcome;
 pub use create_inputs::CreateInputs;
 pub use create_outcome::CreateOutcome;
-use primitives::{Bytes};
+use primitives::Bytes;
 
 use crate::{Gas, InstructionResult, InterpreterResult, SharedMemory};
 use std::boxed::Box;

--- a/crates/op-revm/src/result.rs
+++ b/crates/op-revm/src/result.rs
@@ -1,5 +1,5 @@
 //! Contains the `[OpHaltReason]` type.
-use revm::context_interface::result::HaltReason;
+use revm::context_interface::result::{HaltReason, HaltReasonTr};
 
 /// Optimism halt reason.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -16,6 +16,8 @@ impl From<HaltReason> for OpHaltReason {
         Self::Base(value)
     }
 }
+
+impl HaltReasonTr for OpHaltReason {}
 
 impl TryFrom<OpHaltReason> for HaltReason {
     type Error = OpHaltReason;


### PR DESCRIPTION
## Summary
- remove Fluent/rWasm-specific variants from base HaltReason
- add HaltReasonTr extension hooks for runtime-specific halt mapping
- wire InstructionResult conversion and op-revm HaltReasonTr implementation

## Checks
- cargo check -p revm-context-interface -p revm-interpreter -p op-revm
- cargo test -p revm-interpreter runtime_halt
- cargo fmt --check -p revm-context-interface -p revm-interpreter -p op-revm